### PR TITLE
Fix big-int vs. float bug due to missing type in codegen

### DIFF
--- a/src/event-handlers/NonfungiblePositionManager.ts
+++ b/src/event-handlers/NonfungiblePositionManager.ts
@@ -225,7 +225,7 @@ NonfungiblePositionManagerContract_Transfer_handler(({ event, context }) => {
       withdrawnToken1: 0n,
       amount0: 0n,
       amount1: 0n,
-      totalValueLockedUSD: 0n
+      totalValueLockedUSD: 0,
     } satisfies PositionEntity
   }
 
@@ -257,7 +257,7 @@ NonfungiblePositionManagerContract_Transfer_handler(({ event, context }) => {
 //   return position
 // }
 
-function savePositionSnapshot (position: PositionEntity,
+function savePositionSnapshot(position: PositionEntity,
   event: eventLog<NonfungiblePositionManagerContract_IncreaseLiquidityEvent_eventArgs> | eventLog<NonfungiblePositionManagerContract_TransferEvent_eventArgs>,
   context: NonfungiblePositionManagerContract_IncreaseLiquidityEvent_handlerContextAsync | NonfungiblePositionManagerContract_DecreaseLiquidityEvent_handlerContextAsync | NonfungiblePositionManagerContract_TransferEvent_handlerContext
 ): void {

--- a/test/test.ts
+++ b/test/test.ts
@@ -55,7 +55,7 @@ describe('Transfers', () => {
       token1_id: '0xeCE555d37C37D55a6341b80cF35ef3BC57401d1A',
       withdrawnToken0: 0n,
       withdrawnToken1: 0n,
-      totalValueLockedUSD: 0n
+      totalValueLockedUSD: 0
     }
 
     const swapEvent = Pool.Swap.createMockEvent({


### PR DESCRIPTION
I noticed this when I fixed the error about the float type:
```
gengnerated/src/Types.gen.ts:8:82 - error TS2307: Cannot find module './GqlDbCustomTypes.gen' or its corresponding type declarations.
8 import type {Float_dbNumericFloat as GqlDbCustomTypes_Float_dbNumericFloat} from './GqlDbCustomTypes.gen';
```

Forgot to make the patch last night.